### PR TITLE
Return publication manifest to HTAN config

### DIFF
--- a/HTAN/dca-template-config.json
+++ b/HTAN/dca-template-config.json
@@ -366,6 +366,11 @@
       "type": "record"
     },
     {
+      "display_name": "Publication Manifest",
+      "schema_name": "PublicationManifest",
+      "type": "record"
+    },
+    {
       "display_name": "SRRS Biospecimen",
       "schema_name": "SRRSBiospecimen",
       "type": "record"


### PR DESCRIPTION
As discussed with @mialy-defelice, @afwillia and @AmyHeiser. We manually return the Publication Manifest to the HTAN config