### PR TITLE
Fix typo in dca-template-config.json

### DIFF
--- a/ADKP/dca-template-config.json
+++ b/ADKP/dca-template-config.json
@@ -107,7 +107,7 @@
       },
       {
         "display_name": "biospecimen_metadata_template",
-        "schema_name": "BiospecimenqMetadataTemplate",
+        "schema_name": "BiospecimenMetadataTemplate",
         "type": "record"
       },
       {


### PR DESCRIPTION
Realized this typo is causing manifest generation and validation errors when trying to use DCA for AD Portal. 