### PR TITLE
Change staging config file to point to ncihtan/data-models repo

### DIFF
--- a/HTAN/dca_config.json
+++ b/HTAN/dca_config.json
@@ -4,7 +4,7 @@
     "synapse_asset_view": "syn20446927",
     "data_model_url": "https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld",
     "data_model_info": "",
-    "template_menu_config_file": "https://raw.githubusercontent.com/Sage-Bionetworks/data_curator_config/main/HTAN/dca-template-config.json",
+    "template_menu_config_file": "https://raw.githubusercontent.com/ncihtan/data-models/main/dca-template-config.json",
     "logo_location": "https://raw.githubusercontent.com/Sage-Bionetworks/data_curator_config/main/HTAN/HTAN_text_logo.png",
     "logo_link": "https://humantumoratlas.org",
     "dcc_help_link": "",


### PR DESCRIPTION
This PR points the staging DCA towards the config file now hosted in the ncihtan/data-models repo