### PR TITLE
Update HTAN to v24.1.2 data model

### DIFF
--- a/HTAN/dca_config.json
+++ b/HTAN/dca_config.json
@@ -2,7 +2,7 @@
   "dcc": {
     "name": "HTAN All Projects",
     "synapse_asset_view": "syn20446927",
-    "data_model_url": "https://raw.githubusercontent.com/ncihtan/data-models/v24.1.1/HTAN.model.jsonld",
+    "data_model_url": "https://raw.githubusercontent.com/ncihtan/data-models/v24.1.2/HTAN.model.jsonld",
     "data_model_info": "",
     "template_menu_config_file": "https://raw.githubusercontent.com/ncihtan/data-models/main/dca-template-config.json",
     "logo_location": "https://raw.githubusercontent.com/Sage-Bionetworks/data_curator_config/prod/HTAN/HTAN_text_logo.png",


### PR DESCRIPTION
This PR updates HTAN DCA to the v24.1.2 data model which unblocks a contributor at Stanford. Thanks for merging @afwillia!