### PR TITLE
Switch HTAN to CSV data model in staging

### DIFF
--- a/HTAN/dca_config.json
+++ b/HTAN/dca_config.json
@@ -2,7 +2,7 @@
   "dcc": {
     "name": "HTAN All Projects",
     "synapse_asset_view": "syn20446927",
-    "data_model_url": "https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld",
+    "data_model_url": "https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.csv",
     "data_model_info": "",
     "template_menu_config_file": "https://raw.githubusercontent.com/ncihtan/data-models/main/dca-template-config.json",
     "logo_location": "https://raw.githubusercontent.com/Sage-Bionetworks/data_curator_config/main/HTAN/HTAN_text_logo.png",


### PR DESCRIPTION
FYI @AmyHeiser, as discussed we would like to test using the HTAN CSV model in staging as it may lead to a speed up and avoid gateway timeout errors ahead of future fixes