### PR TITLE
Update AD DCA config

### DIFF
--- a/ADKP/dca_config.json
+++ b/ADKP/dca_config.json
@@ -18,7 +18,7 @@
   },
   "schematic": {
     "global": {
-      "data_model_labels": "class_Label"
+      "data_model_labels": "class_label"
     }
     "manifest_generate": {
       "output_format": "excel",

--- a/ADKP/dca_config.json
+++ b/ADKP/dca_config.json
@@ -17,15 +17,19 @@
     "sidebar_col": "#191919"
   },
   "schematic": {
+    "global": {
+      "data_model_labels": "class_Label"
+    }
     "manifest_generate": {
       "output_format": "excel",
-      "use_annotations": false
+      "use_annotations": true
     },
     "model_validate": {
       "restrict_rules": false
     },
     "model_submit": {
-      "use_schema_labels": true,
+      "table_column_names": "display_label",
+      "annotation_keys": "display_label",
       "table_manipulation": "replace",
       "manifest_record_type": "file_only",
       "hide_blanks": false


### PR DESCRIPTION
Updating to make use of changes in schematic 24.2.1

use display_label option for annotation keys, table column names; make default for data_model_labels explicit; use_annotations = true