### PR TITLE
Fds 1981 cross manifest valiation

### DIFF
--- a/schemas/dca_config.schema.json
+++ b/schemas/dca_config.schema.json
@@ -135,11 +135,18 @@
         "model_validate": {
           "description": "Parameteres to pass to Schematic model validate",
           "type": "object",
-          "required": [ "restrict_rules" ],
+          "required": [
+            "restrict_rules",
+            "enable_cross_manifest_validation"
+            ],
           "additionalProperties": false,
           "properties": {
             "restrict_rules": {
               "description": "Schematic model validate option",
+              "type": "boolean"
+            },
+            "enable_cross_manifest_validation": {
+              "description": "Use cross manifest validation",
               "type": "boolean"
             }
           }

--- a/test/test_cross_manifest_validation_type_dca_config.json
+++ b/test/test_cross_manifest_validation_type_dca_config.json
@@ -22,7 +22,8 @@
       "use_annotations": false
     },
     "model_validate": {
-      "restrict_rules": false
+      "restrict_rules": false,
+      "enable_cross_manifest_validation": true
     },
     "model_submit": {
       "use_schema_labels": true,


### PR DESCRIPTION
Add `enable_cross_manifest_validation` to the config file. This is a true/false value that enables schematic's cross-manifest validation with the default project scope of all projects the user has access to.