### PR TITLE
HTAN file_annotations_upload = FALSE

### DIFF
--- a/HTAN/dca_config.json
+++ b/HTAN/dca_config.json
@@ -28,7 +28,8 @@
       "use_schema_labels": true,
       "table_manipulation": "replace",
       "manifest_record_type": "file_only",
-      "hide_blanks": false
+      "hide_blanks": false,
+      "file_annotations_upload": false
     }
   }
 }


### PR DESCRIPTION
By default, DCA and schematic's submit sets file_annotations_upload = TRUE. Setting this to FALSE in the config may resolve FDS-2281. But ONLY IF uploading annotations is NOT wanted.