### PR TITLE
Remove extra characters from config

### DIFF
--- a/EL/dca_config.json
+++ b/EL/dca_config.json
@@ -4,7 +4,7 @@
     "synapse_asset_view": "syn51753858",
     "data_model_url": "https://raw.githubusercontent.com/eliteportal/data-models/main/EL.data.model.jsonld",
     "data_model_info": "https://eliteportal.github.io/data-dictionary/",
-    "template_menu_config_file": "https://raw.githubusercontent.com/eliteportal/data-models/main/dca-template-config.json",",
+    "template_menu_config_file": "https://raw.githubusercontent.com/eliteportal/data-models/main/dca-template-config.json",
     "logo_location": "https://github.com/eliteportal/data-models/blob/main/assets/ELITE_logo.png",
     "logo_link": "https://eliteportal.synapse.org/",
     "dcc_help_link": "",


### PR DESCRIPTION
There was an extra " and , at the end of the data_model_location. @ameliakallaher FYI