### PR TITLE
temporarily remove HTAN 2

### DIFF
--- a/tenants.json
+++ b/tenants.json
@@ -49,11 +49,6 @@
       "name":"DCA Demo Upsert",
       "synapse_asset_view":"syn51489635",
       "config_location":"demo_upsert/dca_config.json"
-    },
-    {
-      "name":"HTAN Phase 2 All Projects",
-      "synapse_asset_view":"syn20446927",
-      "config_location":"HTAN2/dca_config.json"
     }
   ]
 }


### PR DESCRIPTION
Remove HTAN 2 until it has a different synapse_asset_view than HTAN 1 OR DCA has been updated to handle duplicate synapse_asset_views