### PR TITLE
Restore HTAN 2 pointing to correct asset view

### DIFF
--- a/HTAN/dca_config.json
+++ b/HTAN/dca_config.json
@@ -1,6 +1,6 @@
 {
   "dcc": {
-    "name": "HTAN All Projects",
+    "name": "HTAN Phase 1 All Projects",
     "synapse_asset_view": "syn20446927",
     "data_model_url": "https://raw.githubusercontent.com/ncihtan/data-models/v24.9.1/HTAN.model.jsonld",
     "data_model_info": "",

--- a/HTAN2/dca_config.json
+++ b/HTAN2/dca_config.json
@@ -1,6 +1,6 @@
 {
   "dcc": {
-    "name": "HTAN All Projects",
+    "name": "HTAN Phase 2 All Projects",
     "synapse_asset_view": "syn63714258",
     "data_model_url": "https://raw.githubusercontent.com/ncihtan/data-models/v24.9.1/HTAN.model.jsonld",
     "data_model_info": "",

--- a/HTAN2/dca_config.json
+++ b/HTAN2/dca_config.json
@@ -1,7 +1,7 @@
 {
   "dcc": {
     "name": "HTAN All Projects",
-    "synapse_asset_view": "syn20446927",
+    "synapse_asset_view": "syn63714258",
     "data_model_url": "https://raw.githubusercontent.com/ncihtan/data-models/v24.9.1/HTAN.model.jsonld",
     "data_model_info": "",
     "template_menu_config_file": "https://raw.githubusercontent.com/ncihtan/data-models/v24.9.1/dca-template-config.json",

--- a/tenants.json
+++ b/tenants.json
@@ -49,6 +49,11 @@
       "name":"DCA Demo Upsert",
       "synapse_asset_view":"syn51489635",
       "config_location":"demo_upsert/dca_config.json"
+    },
+    {
+      "name":"HTAN Phase 2 All Projects",
+      "synapse_asset_view":"syn63714258",
+      "config_location":"HTAN2/dca_config.json"
     }
   ]
 }


### PR DESCRIPTION
This PR corrects the HTAN2 deployment by pointing towards the correct asset view in both the `tenants.json` and `HTAN/dca_config.json` files

FYI @afwillia 