### PR TITLE
[DPE-1721] Delete NF-OSI tenant from configuration 

### DIFF
--- a/tenants.json
+++ b/tenants.json
@@ -11,11 +11,6 @@
       "config_location":"VEOIBD/dca_config.json"
     },
     {
-      "name":"NF-OSI",
-      "synapse_asset_view":"syn16858331",
-      "config_location":"NF-OSI/dca_config.json"
-    },
-    {
       "name":"DCA Demo Upsert",
       "synapse_asset_view":"syn51489635",
       "config_location":"demo_upsert/dca_config.json"


### PR DESCRIPTION
Removed NF-OSI tenant entry from tenants.json

According to data manager consensus, planning to transition everything to Curator at the end of March.